### PR TITLE
modifying mentorquestion api 

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -30,7 +30,7 @@ from resources.access import Access
 from resources.group import (Group, GroupRegister, SearchUserGroups, 
 							 UsersInGroup, GenerateGroupCode)
 from resources.logged_answer import LoggedAnswer, GetLoggedAnswerCSV
-from resources.mentors import (MentorPreference, StudentResponses, MentorQuestions,
+from resources.mentors import (MentorPreference, StudentResponses, CreateMentorQuestions, GetMentorQuestions,
 							   ModifyMentorQuestions, DeleteMentorQuestion,
 							   GetMultipleChoiceOptions, ModifyMultipleChoiceOption,
 							   DeleteMultipleChoiceOption)
@@ -173,7 +173,8 @@ api.add_resource(ChangePassword, API_ENDPOINT_PREFIX+'changepassword')
 api.add_resource(ForgotUsername, API_ENDPOINT_PREFIX+'forgotusername', resource_class_kwargs={'mail' : mail})
 api.add_resource(MentorPreference, API_ENDPOINT_PREFIX + 'mentorpreference')
 api.add_resource(StudentResponses, API_ENDPOINT_PREFIX + 'studentresponses')
-api.add_resource(MentorQuestions, API_ENDPOINT_PREFIX + 'mentorquestions')
+api.add_resource(CreateMentorQuestions, API_ENDPOINT_PREFIX + 'creatementorquestions')
+api.add_resource(GetMentorQuestions, API_ENDPOINT_PREFIX + 'getmentorquestions')
 api.add_resource(ModifyMentorQuestions, API_ENDPOINT_PREFIX + 'modifymentorquestions')
 api.add_resource(DeleteMentorQuestion, API_ENDPOINT_PREFIX + 'deletementorquestions')
 api.add_resource(GetMultipleChoiceOptions, API_ENDPOINT_PREFIX + 'getmultiplechoiceoptions')

--- a/resources/mentors.py
+++ b/resources/mentors.py
@@ -140,8 +140,8 @@ class StudentResponses(Resource):
                 cursor.close()
                 conn.close()
 
-#Create and Read mentor questions
-class MentorQuestions(Resource):
+#Create mentor questions
+class CreateMentorQuestions(Resource):
     def post(self):
         data = {}
         data['type'] = getParameter("type", str, True, "")
@@ -180,7 +180,10 @@ class MentorQuestions(Resource):
                 cursor.close()
                 conn.close()
 
-    def get(self):
+class GetMentorQuestions(Resource):
+
+    # @jwt_required
+    def post(self):
         data = {}
         data['moduleID'] = getParameter("moduleID", str, True, "")
 
@@ -193,7 +196,15 @@ class MentorQuestions(Resource):
             conn = mysql.connect()
             cursor = conn.cursor()
 
-            mentorQuestions = get_mentor_questions(data['moduleID'], conn, cursor)
+            result = get_mentor_questions(data['moduleID'], conn, cursor)
+
+            mentorQuestions = []
+            for row in result:
+                question = {}
+                question['questionID'] = row[0]
+                question['type'] = row[1]
+                question['questionText'] = row[2]
+                mentorQuestions.append(question)
 
             raise ReturnSuccess(mentorQuestions, 200)
 
@@ -210,7 +221,6 @@ class MentorQuestions(Resource):
             if (conn.open):
                 cursor.close()
                 conn.close()
-
 
 #Modify mentor questions
 class ModifyMentorQuestions(Resource):


### PR DESCRIPTION
Chnages:

1) Modifed Get mentor question API to return a JSON array instead of a 2D array

2) Split mentor question api since Unity does not allow form inputs on GET requests, so the get request for mentor questions is now a separate API that use a POST and the original mentorquestion API is now creatementorquestion