### PR TITLE
Update Term, Question, and Phase buttons

### DIFF
--- a/templates/src/components/Modules/Phrase.js
+++ b/templates/src/components/Modules/Phrase.js
@@ -153,6 +153,12 @@ class Phrase extends React.Component {
         let imgLink = this.state.baseURL + selectedImgFile;
         let audioLink = this.state.baseURL + selectedAudioFile;
 
+        let disableImgButton = !selectedImgFile;
+        let disableAudioButton = !selectedAudioFile;
+
+        let imgButtonClass = disableImgButton ? 'disabled-btn' : 'enabled-btn';
+        let audioButtonClass = disableAudioButton ? 'disabled-btn' : 'enabled-btn';
+
         return (
             <>
             {editMode === false ? 
@@ -160,15 +166,15 @@ class Phrase extends React.Component {
                     <td>{editedFront}</td>
                     <td>{editedBack}</td>
                     <td>
-                        {/* favicon is just a placeholder for now more testing needs to be done after deployment */}
-                        <Button style={{backgroundColor: 'white', width: '100%'}} href={imgLink} download>
-                        <img src={require('../../Images/image.png')} alt="frame icon" style={{width: '25px', height: '25px'}}/>
+                        {/* Add disabled attribute to disable button if no image file found */}
+                        <Button className={`image-btn ${imgButtonClass}`} href={imgLink} download disabled={disableImgButton}>
+                            <img src={require('../../Images/image.png')} alt="frame icon" style={{ width: '25px', height: '25px' }} />
                         </Button>
                     </td>
                     <td>
-                        {/* audio has to be in the same domain */}
-                        <Button style={{backgroundColor: 'white', width: '100%'}} href={audioLink} download> 
-                        <img src={require('../../Images/headphones.png')} alt="headphones icon" style={{width: '25px', height: '25px'}}/>
+                        {/* Add disabled attribute to disable button if no audio file found */}
+                        <Button className={`audio-btn ${audioButtonClass}`} href={audioLink} download disabled={disableAudioButton}>
+                            <img src={require('../../Images/headphones.png')} alt="headphones icon" style={{ width: '25px', height: '25px' }} />
                         </Button>
                     </td>
                     

--- a/templates/src/components/Modules/Question.js
+++ b/templates/src/components/Modules/Question.js
@@ -286,20 +286,18 @@ class Question extends React.Component {
         <Fragment>
         <tr onClick={this.toggleCollapsedAnswers}>
           <td>{question.questionText}</td>
-          <td>
             <td>
               {/* Add disabled attribute to disable button if no image file found */}
-               <Button className={`image-btn ${imgButtonClass}`} href={imgLink} download disabled={disableImgButton}>
-                  <img src={require('../../Images/image.png')} alt="frame icon" style={{ width: '25px', height: '25px' }} />
-                </Button>
+              <Button className={`image-btn ${imgButtonClass}`} href={imgLink} download disabled={disableImgButton}>
+                <img src={require('../../Images/image.png')} alt="frame icon" style={{ width: '25px', height: '25px' }} />
+              </Button>
             </td>
             <td>
               {/* Add disabled attribute to disable button if no audio file found */}
               <Button className={`audio-btn ${audioButtonClass}`} href={audioLink} download disabled={disableAudioButton}>
                 <img src={require('../../Images/headphones.png')} alt="headphones icon" style={{ width: '25px', height: '25px' }} />
-               </Button>
+              </Button>
             </td>
-          </td>
 
           {this.props.permissionLevel !== "st"
           ?

--- a/templates/src/components/Modules/Question.js
+++ b/templates/src/components/Modules/Question.js
@@ -275,37 +275,30 @@ class Question extends React.Component {
     let imgLink = this.state.baseURL + selectedImgFile;
     let audioLink = this.state.baseURL + selectedAudioFile;
 
+    let disableImgButton = !selectedImgFile;
+    let disableAudioButton = !selectedAudioFile;
+
+    let imgButtonClass = disableImgButton ? 'disabled-btn' : 'enabled-btn';
+    let audioButtonClass = disableAudioButton ? 'disabled-btn' : 'enabled-btn';
+
     if (this.state.editMode === false){
       return (
         <Fragment>
         <tr onClick={this.toggleCollapsedAnswers}>
           <td>{question.questionText}</td>
           <td>
-            <Button 
-              style={{backgroundColor: 'white', width: '100%'}} 
-              href={imgLink} 
-              download
-              >
-              <img 
-                src={require('../../Images/image.png')} 
-                alt="frame icon" 
-                style={{width: '25px', height: '25px'}}
-                />
-            </Button>
-          </td>
-          <td>
-            {/* audio has to be in the same domain */}
-            <Button 
-              style={{backgroundColor: 'white', width: '100%'}} 
-              href={audioLink} 
-              download
-              > 
-              <img 
-                src={require('../../Images/headphones.png')} 
-                alt="headphones icon" 
-                style={{width: '25px', height: '25px'}}
-                />
-            </Button>
+            <td>
+              {/* Add disabled attribute to disable button if no image file found */}
+               <Button className={`image-btn ${imgButtonClass}`} href={imgLink} download disabled={disableImgButton}>
+                  <img src={require('../../Images/image.png')} alt="frame icon" style={{ width: '25px', height: '25px' }} />
+                </Button>
+            </td>
+            <td>
+              {/* Add disabled attribute to disable button if no audio file found */}
+              <Button className={`audio-btn ${audioButtonClass}`} href={audioLink} download disabled={disableAudioButton}>
+                <img src={require('../../Images/headphones.png')} alt="headphones icon" style={{ width: '25px', height: '25px' }} />
+               </Button>
+            </td>
           </td>
 
           {this.props.permissionLevel !== "st"

--- a/templates/src/components/Modules/Term.js
+++ b/templates/src/components/Modules/Term.js
@@ -252,6 +252,12 @@ class Term extends React.Component {
     let imgLink = this.state.baseURL + selectedImgFile;
     let audioLink = this.state.baseURL + selectedAudioFile;
 
+    let disableImgButton = !selectedImgFile;
+    let disableAudioButton = !selectedAudioFile;
+
+    let imgButtonClass = disableImgButton ? 'disabled-btn' : 'enabled-btn';
+    let audioButtonClass = disableAudioButton ? 'disabled-btn' : 'enabled-btn';
+
     if (this.state.editMode === false){
       return (
         <Fragment>
@@ -261,32 +267,17 @@ class Term extends React.Component {
           <td>{editedType}</td>
           <td>{editedGender}</td>
           <td>
-            <Button 
-              style={{backgroundColor: 'white', width: '100%'}} 
-              href={imgLink}
-              download
-              >
-              <img 
-                src={require('../../Images/image.png')} 
-                alt="frame icon" 
-                style={{width: '25px', height: '25px'}}
-                />
-            </Button>
-          </td>
-          <td>
-            {/* audio has to be in the same domain */}
-            <Button 
-              style={{backgroundColor: 'white', width: '100%'}} 
-              href={audioLink} 
-              download
-              > 
-              <img 
-                src={require('../../Images/headphones.png')} 
-                alt="headphones icon" 
-                style={{width: '25px', height: '25px'}}
-                />
-            </Button>
-          </td>
+                        {/* Add disabled attribute to disable button if no image file found */}
+                        <Button className={`image-btn ${imgButtonClass}`} href={imgLink} download disabled={disableImgButton}>
+                            <img src={require('../../Images/image.png')} alt="frame icon" style={{ width: '25px', height: '25px' }} />
+                        </Button>
+                    </td>
+                    <td>
+                        {/* Add disabled attribute to disable button if no audio file found */}
+                        <Button className={`audio-btn ${audioButtonClass}`} href={audioLink} download disabled={disableAudioButton}>
+                            <img src={require('../../Images/headphones.png')} alt="headphones icon" style={{ width: '25px', height: '25px' }} />
+                        </Button>
+                    </td>
 
           {this.props.permissionLevel !== "st" 
           ? 

--- a/templates/src/stylesheets/style.css
+++ b/templates/src/stylesheets/style.css
@@ -1192,6 +1192,18 @@ table.classTable tbody th {
 /*--------------------------------------------------------------
 # Module List Tabs
 --------------------------------------------------------------*/
+.enabled-btn {
+  background-color: white !important;
+  color: black !important;
+}
+
+.disabled-btn {
+  background-color: lightgray !important;
+  color: gray !important;
+}
+
+
+
 nav.nav.nav-tabs {
   border-bottom-style: hidden
 }


### PR DESCRIPTION
Adjusted the audio and image buttons for the terms, questions and phases so it is grayed out if there is no image/audio, and white/clickable if there is