### PR TITLE
Refactored UserMessages.post 

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -152,6 +152,8 @@ from resources.conversationElle.conversation import(
     PFGetStudentMessages,
     GetTermProgress,
     GenerateModule,
+    GenerateTitoResponse,
+    TitoMessages,
 
     # Testing,
     # AIModuleGeneration,
@@ -397,6 +399,8 @@ api.add_resource(GetALValues, API_ENDPOINT_PREFIX + "adaptivelearning/gettermlis
 # ===============================================
 api.add_resource(TitoAccess, API_ENDPOINT_PREFIX + "twt/session/access")
 api.add_resource(ChatbotSessions, API_ENDPOINT_PREFIX + "twt/session/create")
+api.add_resource(GenerateTitoResponse, API_ENDPOINT_PREFIX + "twt/session/generate")
+api.add_resource(TitoMessages, API_ENDPOINT_PREFIX + "twt/session/tito_messages")
 api.add_resource(UserMessages, API_ENDPOINT_PREFIX + "twt/session/messages")
 api.add_resource(UserAudio, API_ENDPOINT_PREFIX + "twt/session/audio")
 api.add_resource(ModuleTerms, API_ENDPOINT_PREFIX + "twt/module/terms")

--- a/resources/conversationElle/conversation.py
+++ b/resources/conversationElle/conversation.py
@@ -195,27 +195,10 @@ class UserMessages(Resource):
         # Update module words used =>
         # Async grammar evaluation
 
-        # Sends a message to tito with safety check
-        tito_response = ''
-        try:
-            
-            tito_response = handle_message_with_context(message = message, module_id = module_id, session_id = session_id)
-            # print(f"[DEBUG] session_id={session_id}, module_id={module_id}")
-            
-            # tito_response = tito_response_data.get('response', "Sorry, I could not understand your message. Please try again!")
-            # print(tito_response)
-            
-            # TODO: Verify data
-            if module_id != REAL_FREE_CHAT_MODULE:
-                newTitoMessage(user_id, session_id, class_id, tito_response, module_id)
+        # Return early after saving user message
+        return create_response(True, message="Message sent.", data=message, resumeMessaging=True, messageID=new_msg_id)
 
-        except Exception as error:
-            tito_response = "Sorry, there is a bit of trouble. Please try again!"
-            tito_response_data = {"response": tito_response}
-        
-        return create_response(True, message="Message sent.", data=message, resumeMessaging=True, messageID=new_msg_id, titoResponse=tito_response)
-
-
+ 
     @jwt_required
     def get(self):
         '''
@@ -323,6 +306,54 @@ class UserAudio(Resource):
         if not res:
             return create_response(False, message="Error occurred when inserting vm data into DB.")
         return create_response(True, message="Audio message uploaded successfully.")
+
+class GenerateTitoResponse(Resource):
+    @jwt_required
+    def post(self):
+        '''
+        /elleapi/twt/session/generate
+            Generates an LLM response for a given message
+        '''
+        data = request.form
+        message = data.get('message')
+        module_id = int(data.get('moduleID'))
+        session_id = data.get('chatbotSID')
+        
+        if not message or not module_id or not session_id:
+            return create_response(False, message="Missing required parameters.", status_code=404)
+            
+        try:
+            tito_response = handle_message_with_context(message=message, module_id=module_id, session_id=session_id)
+            return create_response(True, message="LLM response generated.", titoResponse=tito_response)
+        except Exception as e:
+            print(f"[GENERATE ERROR] {e}")
+            tito_response = "Sorry, there is a bit of trouble. Please try again!"
+            return create_response(False, message="LLM generation failed.", status_code=500, titoResponse=tito_response)
+
+class TitoMessages(Resource):
+    @jwt_required
+    def post(self):
+        '''
+        /elleapi/twt/session/tito_messages
+            Saves Tito's response to the database
+        '''
+        user_id = get_jwt_identity()
+        data = request.form
+        session_id = data.get('chatbotSID')
+        class_id = data.get('classID')
+        module_id = int(data.get('moduleID'))
+        tito_response = data.get('titoResponse')
+        
+        if not session_id or not module_id or not tito_response or not class_id:
+            return create_response(False, message="Missing required parameters.", status_code=404)
+            
+        try:
+            newTitoMessage(user_id, session_id, class_id, tito_response, module_id)
+            return create_response(True, message="Tito message saved.")
+        except Exception as e:
+            print(f"[SAVE ERROR] {e}")
+            return create_response(False, message="Failed to save Tito message.", status_code=500)
+
 
     @jwt_required
     def get(self):

--- a/resources/conversationElle/conversation.py
+++ b/resources/conversationElle/conversation.py
@@ -222,6 +222,54 @@ class UserMessages(Resource):
         except Exception as e:
             return create_response(False, message=f"Failed to retrieve user's messages. Error: {e}", status_code=504)
 
+
+class GenerateTitoResponse(Resource):
+    @jwt_required
+    def post(self):
+        '''
+        /elleapi/twt/session/generate
+            Generates an LLM response for a given message
+        '''
+        data = request.form
+        message = data.get('message')
+        module_id = int(data.get('moduleID'))
+        session_id = data.get('chatbotSID')
+        
+        if not message or not module_id or not session_id:
+            return create_response(False, message="Missing required parameters.", status_code=404)
+            
+        try:
+            tito_response = handle_message_with_context(message=message, module_id=module_id, session_id=session_id)
+            return create_response(True, message="LLM response generated.", titoResponse=tito_response)
+        except Exception as e:
+            print(f"[GENERATE ERROR] {e}")
+            tito_response = "Sorry, there is a bit of trouble. Please try again!"
+            return create_response(False, message="LLM generation failed.", status_code=500, titoResponse=tito_response)
+
+class TitoMessages(Resource):
+    @jwt_required
+    def post(self):
+        '''
+        /elleapi/twt/session/tito_messages
+            Saves Tito's response to the database
+        '''
+        user_id = get_jwt_identity()
+        data = request.form
+        session_id = data.get('chatbotSID')
+        class_id = data.get('classID')
+        module_id = int(data.get('moduleID'))
+        tito_response = data.get('titoResponse')
+        
+        if not session_id or not module_id or not tito_response or not class_id:
+            return create_response(False, message="Missing required parameters.", status_code=404)
+            
+        try:
+            newTitoMessage(user_id, session_id, class_id, tito_response, module_id)
+            return create_response(True, message="Tito message saved.")
+        except Exception as e:
+            print(f"[SAVE ERROR] {e}")
+            return create_response(False, message="Failed to save Tito message.", status_code=500)
+
 class UserAudio(Resource):
     @jwt_required
     def post(self):
@@ -307,54 +355,6 @@ class UserAudio(Resource):
             return create_response(False, message="Error occurred when inserting vm data into DB.")
         return create_response(True, message="Audio message uploaded successfully.")
 
-class GenerateTitoResponse(Resource):
-    @jwt_required
-    def post(self):
-        '''
-        /elleapi/twt/session/generate
-            Generates an LLM response for a given message
-        '''
-        data = request.form
-        message = data.get('message')
-        module_id = int(data.get('moduleID'))
-        session_id = data.get('chatbotSID')
-        
-        if not message or not module_id or not session_id:
-            return create_response(False, message="Missing required parameters.", status_code=404)
-            
-        try:
-            tito_response = handle_message_with_context(message=message, module_id=module_id, session_id=session_id)
-            return create_response(True, message="LLM response generated.", titoResponse=tito_response)
-        except Exception as e:
-            print(f"[GENERATE ERROR] {e}")
-            tito_response = "Sorry, there is a bit of trouble. Please try again!"
-            return create_response(False, message="LLM generation failed.", status_code=500, titoResponse=tito_response)
-
-class TitoMessages(Resource):
-    @jwt_required
-    def post(self):
-        '''
-        /elleapi/twt/session/tito_messages
-            Saves Tito's response to the database
-        '''
-        user_id = get_jwt_identity()
-        data = request.form
-        session_id = data.get('chatbotSID')
-        class_id = data.get('classID')
-        module_id = int(data.get('moduleID'))
-        tito_response = data.get('titoResponse')
-        
-        if not session_id or not module_id or not tito_response or not class_id:
-            return create_response(False, message="Missing required parameters.", status_code=404)
-            
-        try:
-            newTitoMessage(user_id, session_id, class_id, tito_response, module_id)
-            return create_response(True, message="Tito message saved.")
-        except Exception as e:
-            print(f"[SAVE ERROR] {e}")
-            return create_response(False, message="Failed to save Tito message.", status_code=500)
-
-
     @jwt_required
     def get(self):
         '''
@@ -394,6 +394,8 @@ class TitoMessages(Resource):
             return create_response(False, message="File does not exist.", status_code=404)
 
         return send_file(file_path, mimetype="audio/webm")
+
+
 
 class FetchAllUserAudio(Resource):
     @jwt_required

--- a/templates/services/TitoService.tsx
+++ b/templates/services/TitoService.tsx
@@ -13,10 +13,10 @@ import axios from 'axios';
 //   }
 // };
 
+// CHDR: session management, permission checks, analytics (validates against real CHDR DB)
 export const ELLE_URL = 'https://chdr.cs.ucf.edu/elleapi';
-//const ELLE_URL = 'http://159.65.232.73/elleapi';
-// Connect directly to Flask backend running on port 5050
-// export const ELLE_URL = 'http://localhost:5050/elleapi';
+// LOCAL: ONLY sendMessage -> local Flask -> local llama.cpp (for local testing)
+export const LOCAL_URL = 'http://localhost:5050/elleapi';
 
 
 interface Module {
@@ -495,8 +495,26 @@ export const sendMessage = async (access_token: string, userId: number, chatbotI
     
     console.log(`[SendMessage] Sending with original session ID: ${chatbotId}, classID: ${finalClassId}`);
     
-    const response = await axios.post(
+    // Step 1: Save User Message to Production DB (CHDR)
+    console.log(`[SendMessage] Step 1: Saving user message to DB...`);
+    const userMessageResponse = await axios.post(
       `${ELLE_URL}/twt/session/messages`,
+      formData,
+      {
+        headers: { 
+          Authorization: `Bearer ${access_token}`,
+          'Content-Type': 'multipart/form-data'
+        }
+      }
+    );
+    
+    const messageID = userMessageResponse.data.messageID || userMessageResponse.data.data?.messageID;
+    console.log(`[SendMessage] Step 1 Complete: messageID=${messageID}`);
+
+    // Step 2: Generate LLM Response (Local localhost)
+    console.log(`[SendMessage] Step 2: Generating LLM response...`);
+    const generateResponse = await axios.post(
+      `${ELLE_URL}/twt/session/generate`, // change to LOCAL_URL for local testing
       formData,
       {
         headers: { 
@@ -507,21 +525,32 @@ export const sendMessage = async (access_token: string, userId: number, chatbotI
       }
     );
     
-    // Debug: Log the full response structure
-    console.log("[DEBUG] Full backend response:");
-    console.log(response.data);
+    const titoResponse = generateResponse.data.titoResponse;
+    console.log(`[SendMessage] Step 2 Complete: titoResponse received`);
+
+    // Step 3: Save Tito's Response to Production DB (CHDR)
+    console.log(`[SendMessage] Step 3: Saving Tito's response to DB...`);
+    const titoFormData = new FormData();
+    titoFormData.append('chatbotSID', chatbotId.toString());
+    titoFormData.append('classID', finalClassId?.toString()??"");
+    titoFormData.append('moduleID', moduleId.toString());
+    titoFormData.append('titoResponse', titoResponse);
+
+    await axios.post(
+      `${ELLE_URL}/twt/session/tito_messages`,
+      titoFormData,
+      {
+        headers: { 
+          Authorization: `Bearer ${access_token}`,
+          'Content-Type': 'multipart/form-data'
+        }
+      }
+    );
+    console.log(`[SendMessage] Step 3 Complete: All data synched`);
+
     
-    // Extract response data (backend wraps in response.data)
-    const responseData = response.data;
-    const data = responseData.data || responseData;
-    
-    console.log("[DEBUG] Extracted data:");
-    console.log(data);
-    
-    // Get titoResponse from the top-level response (not nested in data)
-    const titoResponse = responseData.titoResponse || data.titoResponse || data.llmResponse;
-    console.log("[DEBUG] Extracted titoResponse:");
-    console.log(titoResponse);
+
+    const data = generateResponse.data; // Use metadata if returned from generate
     
     if(data && data.metadata && typeof data.metadata === "string") {
       try {
@@ -539,7 +568,7 @@ export const sendMessage = async (access_token: string, userId: number, chatbotI
       llmResponse: titoResponse || "Great job!",
       termsUsed: data.termsUsed || [],
       titoConfused: data.titoConfused || false,
-      messageID: responseData.messageID || data.messageID, // Extract messageID from response
+      messageID: messageID, 
       metadata: data.metadata || {}
     };
     


### PR DESCRIPTION
This PR refactors the chat messaging flow by splitting UserMessages.post into three discrete steps:

- Save User Message: Records the incoming message in the production DB.
- Generate response: Isolates the LLM prompting logic into a standalone endpoint (/twt/session/generate).
- Save Tito Response: Records the generated response back in the production DB.

This refactoring isolates the LLM generation from database-dependent logic, so that different models can be switched out and tested, and hybrid routing between production and local instances can be done.

Refactored the definition on `resources/conversationElle/conversation.py` and the implementation on `templates/services/TitoService.tsx`