### PR TITLE
Implements error, explanation, and score changing for the convo grader (Talking with Tito)

### DIFF
--- a/resources/conversationElle/conversation.py
+++ b/resources/conversationElle/conversation.py
@@ -210,7 +210,10 @@ class UserMessages(Resource):
             usageByTerm=usage_by_term,
             metadata={
                 "score": msg_graded.get("suggested_grade") if msg_graded else None,
-                "error_count": msg_graded.get("error_count") if msg_graded else None
+                "error_count": msg_graded.get("error_count") if msg_graded else None,
+                "error": msg_graded.get("error_words") if msg_graded else None,
+                "correction": msg_graded.get("corrected_text") if msg_graded else None,
+                "explanation": msg_graded.get("explanation_text") if msg_graded else None
             }
         )
 

--- a/resources/conversationElle/convo_grader.py
+++ b/resources/conversationElle/convo_grader.py
@@ -48,22 +48,50 @@ def suggest_grade(message: str, language: str = "auto"):
 
         if total_words == 0:
             grade_score = 0.0
+            error_words = ""
+            corrected_text = message
+            explanation_text = ""
         else:
             error_rate = error_count / total_words
 
             if error_rate == 0: # No errors (A+)
-                grade_score = 100.0
+                grade_score = 10.0
             elif error_rate < 0.10:  # Less than 10% errors (A)
-                grade_score = 90.0
+                grade_score = 9.0
             elif error_rate < 0.20:  # Less than 20% errors (B)
-                grade_score = 80.0
+                grade_score = 8.0
             elif error_rate < 0.30:  # Less than 30% errors (C)
-                grade_score = 70.0
+                grade_score = 7.0
             elif error_rate < 0.40:  # Less than 40% errors (D)
-                grade_score = 60.0
+                grade_score = 6.0
             else:
-                grade_score = 50.0 # Less than 50% errors (F)
+                grade_score = 5.0 # Less than 50% errors (F)
 
+        # Sort matches in reverse order of offset to apply corrections right-to-left
+            sorted_matches = sorted(matches, key=lambda x: x.get('offset', 0), reverse=True)
+            corrected_message = message
+            errors_list = []
+            explanations_list = []
+
+            for match in sorted_matches:
+                offset = match.get('offset', 0)
+                length = match.get('length', 0)
+                original_word = message[offset:offset+length]
+                replacements = match.get('replacements', [])
+                suggested_word = replacements[0].get('value') if replacements else None
+
+                errors_list.append(original_word)
+                explanations_list.append(f"'{original_word}': {match.get('message', 'Incorrect word')}")
+
+                if suggested_word is not None:
+                    corrected_message = corrected_message[:offset] + suggested_word + corrected_message[offset+length:]
+
+            errors_list.reverse()
+            explanations_list.reverse()
+            error_words = ", ".join(errors_list)
+            corrected_text = corrected_message
+            explanation_text = "; ".join(explanations_list)
+            
         detected_language_info = result.get('language', {})
         detected_name = detected_language_info.get('name', 'Unknown')
 
@@ -73,6 +101,9 @@ def suggest_grade(message: str, language: str = "auto"):
             "error_count": error_count,
             "total_words": total_words,
             "detected_language": detected_name,
+            "error_words": error_words,
+            "corrected_text": corrected_text,
+            "explanation_text": explanation_text,
             "errors": matches,
             "status": "success"
         }
@@ -102,12 +133,12 @@ def suggest_grade(message: str, language: str = "auto"):
 # grader testing
 if __name__ == "__main__":
     test_texts = [
-        ("Hello, my name is John and I am twenty years old.", "english"), # Counts this as wrong not entirely sure why
-        ("Hello, my name are John and I am twenty year old.", "english"),
-        ("Hola, me llamo María y tengo veinte años.", "spanish"),
-        ("Hola, me llamas María y tengo veinte año.", "spanish"),
-        ("Bonjour, je m'appelle Pierre.", "french"),
-        ("Hello como estas today?", None),  # Auto-detect
+        ("Hello, my name is John and I am twenty years old.", "en"), 
+        ("Hello, my name are John and I am twenty year old.", "en"),
+        ("Hola, me llamo María y tengo veinte años.", "es"),
+        ("Hola, me llamas María y tengo veinte año.", "es"),
+        ("Bonjour, je m'appelle Pierre.", "fr"),
+        ("Hello como estas today?", "auto"),  # Auto-detect
     ]
     
     print("=== Simple LanguageTool Grade Suggester ===")


### PR DESCRIPTION
This PR enhances the Talking With Tito conversation grading UI. Previously, expanding the message metadata dropdown only displayed a generic numeric score scaled out of 100 (e.g., 100/90/80/70/60/50).

With these changes, the dropdown now dynamically isolates specific grammatical mistakes, provides explicit explanations for why the error occurred, and maps the corrected sentence alongside a rebalanced 1-10 scoring system.

**Verified Test Case (Staging)**
The functionality has been successfully compiled, deployed, and verified live on the CHDR staging server using the following test run:

_**Perfect Input:**_

- User: "Claro, está bien."

- Result: Score: 10 | Error/Explanation: Blanks (No corrections needed).

**_Multiple Errors (Verb Conjugation + Gender Agreement):_**

- User: "Yo sabe que necesito un raqueta."

- Result: Score: 6 | Error: sabe, un raqueta | Explanation: Explicitly identifies the subject-verb mismatch and gender disagreement.

**_Single Error (Plural/Singular Agreement):_**

- User: "Necesito los pelota de tenis."

- Result: Score: 7 | Error: los pelota | Explanation: Catches the article-noun mismatch.