### PR TITLE
Persist vocabulary list reset state in database (Talking with Tito)

### DIFF
--- a/resources/conversationElle/conversation.py
+++ b/resources/conversationElle/conversation.py
@@ -571,6 +571,27 @@ class GetTermProgress(Resource):
             "usageByTerm": usage_by_term
         })
 
+    @jwt_required
+    def post(self):
+        """
+        /elleapi/twt/session/getTermProgress
+        Body/Params: moduleID, chatbotSID
+        Resets term progress for the given module & chatbot session to 0.
+        """
+        user_id = get_jwt_identity()
+        data = request.get_json(silent=True) or request.form
+        module_id = data.get('moduleID') or request.args.get('moduleID')
+        chatbot_sid = data.get('chatbotSID') or request.args.get('chatbotSID')
+        
+        try:
+            module_id = int(module_id)
+            chatbot_sid = int(chatbot_sid)
+        except (TypeError, ValueError):
+            return create_response(False, message="Invalid moduleID or chatbotSID provided", status_code=400)
+            
+        resetTermProgress(user_id, module_id, chatbot_sid)
+        return create_response(True, message="Term progress reset successfully")
+
 
 class GetModuleProgress(Resource):
     @jwt_required

--- a/resources/conversationElle/database.py
+++ b/resources/conversationElle/database.py
@@ -1259,6 +1259,29 @@ def getTermProgress(user_id: int, module_id: int, chatbot_sid: int = None):
         else:
             return []
 
+def resetTermProgress(user_id: int, module_id: int, chatbot_sid: int):
+    # 1. Reset timesUsed, hasMastered, timesMisspelled in tito_term_progress for this specific session
+    db.post('''
+        UPDATE tito_term_progress
+        SET timesUsed = 0, hasMastered = 0, timesMisspelled = 0
+        WHERE userID = %s AND moduleID = %s AND chatbotSID = %s;
+    ''', (user_id, module_id, chatbot_sid))
+
+    # 2. Recalculate and update the termsMastered in tito_module_progress
+    mastered_count_row = db.get('''
+        SELECT COUNT(DISTINCT termID)
+        FROM tito_term_progress
+        WHERE userID = %s AND moduleID = %s AND hasMastered = 1;
+    ''', (user_id, module_id), fetchOne=True)
+    
+    mastered_count = mastered_count_row[0] if mastered_count_row else 0
+    
+    db.post('''
+        INSERT INTO tito_module_progress (userID, moduleID, termsMastered)
+        VALUES (%s, %s, %s)
+        ON DUPLICATE KEY UPDATE termsMastered = %s;
+    ''', (user_id, module_id, mastered_count, mastered_count))
+
 def getUsageByTerm(user_id: int, module_id: int, chatbot_sid: int = None):
     if chatbot_sid:
         query = '''

--- a/templates/components/TalkWithTito/ChatScreen.tsx
+++ b/templates/components/TalkWithTito/ChatScreen.tsx
@@ -18,6 +18,7 @@ import {
   uploadAudioFile, 
   fetchSessions, 
   deleteSession, 
+  resetTermProgress,
   ELLE_URL 
 } from "@/services/TitoService";
 
@@ -313,14 +314,21 @@ export default function ChatScreen(props: ChatScreenProps) {
     };
   }, [progress]);
 
-  const handleReset = useCallback(() => {
+  const handleReset = useCallback(async () => {
+    // 1. Reset local React state immediately for snappy UI
     setTerms((previousTerms) =>
       previousTerms.map((term) => ({
         ...term,
         usageCount: 0,
       }))
     );
-  }, []);
+
+    // 2. Call backend to reset the term progress in the database
+    if (user?.jwt && props.moduleID !== -1 && props.chatbotId !== undefined) {
+      console.log(`[ChatScreen] Resetting term progress in database for module ${props.moduleID}, session ${props.chatbotId}`);
+      await resetTermProgress(user.jwt, props.moduleID, props.chatbotId);
+    }
+  }, [user?.jwt, props.moduleID, props.chatbotId]);
 
   /* Vocabulary mastery state */
   const [masteredSet, setMasteredSet] =

--- a/templates/services/TitoService.tsx
+++ b/templates/services/TitoService.tsx
@@ -889,6 +889,22 @@ export const uploadAudioFile = async (
   }
 };
 
+// Resets term progress for a user, module, and chatbot session
+export const resetTermProgress = async (access_token: string, moduleID: number, chatbotSID: number): Promise<boolean> => {
+  try {
+    const response = await axios.post(`${ELLE_URL}/twt/session/getTermProgress`, {
+      moduleID,
+      chatbotSID
+    }, {
+      headers: { Authorization: `Bearer ${access_token}` }
+    });
+    return response.data.success || false;
+  } catch (error) {
+    handleError(error);
+    return false;
+  }
+};
+
 // Utility function for handling errors
 const handleError = (error: unknown): void => {
   if (axios.isAxiosError(error)) {


### PR DESCRIPTION
**_AI-Generated Description_**

### Summary
This PR integrates the "Reset List" button on the Talk With Tito vocabulary progress panel with the backend database. Previously, resetting progress only cleared the frontend state, which got overwritten upon reloading the page or switching chats. Now, resets are permanently stored in the database.

### Changes
#### Backend
- **`resources/conversationElle/database.py`**: Added `resetTermProgress` to update `tito_term_progress` (resetting `timesUsed`, `hasMastered`, and `timesMisspelled` to 0 for the active session) and keep `tito_module_progress.termsMastered` in sync.
- **`resources/conversationElle/conversation.py`**: Added a `POST` handler to `/elleapi/twt/session/getTermProgress` to serve reset requests.

#### Frontend
- **`templates/services/TitoService.tsx`**: Added the `resetTermProgress` API caller.
- **`templates/components/TalkWithTito/ChatScreen.tsx`**: Updated `handleReset` to invoke the backend service asynchronously while instantly updating the React state for a snappy user experience.