### PR TITLE
Prevents hint bubble requests from updating vocabulary progress (Talking with Tito)

### DIFF
--- a/resources/conversationElle/conversation.py
+++ b/resources/conversationElle/conversation.py
@@ -193,8 +193,8 @@ class UserMessages(Resource):
         # Send to spacy service to parse key terms if NOT in free chat mode
         if module_id != REAL_FREE_CHAT_MODULE:
             hint_word = data.get('hintWord')
-            should_update_db = not bool(hint_word)
-            add_message(message, module_id, user_id, new_msg_id, session_id, update_db=should_update_db)
+            if not hint_word:
+                add_message(message, module_id, user_id, new_msg_id, session_id, update_db=True)
 
         # TODO:
         # Update module words used =>


### PR DESCRIPTION
**_AI-Generated Description_**

### Summary
Fixed a bug where clicking a hint bubble (which generates a user prompt asking Tito for a question about a word) would incorrectly increment that word's `timesUsed` and `timesMisspelled` progress in the database when the session was reloaded/refreshed.

### Changes
- **`resources/conversationElle/conversation.py`**: Skipped sending the user message to the SpaCy queue when `hintWord` is present.
