### PR TITLE
Includes date in chat message timestamp formatting (Talking with Tito)

### DIFF
--- a/templates/components/TalkWithTito/Messages.tsx
+++ b/templates/components/TalkWithTito/Messages.tsx
@@ -46,7 +46,7 @@ function Message({ message,chatFontSize }: MessageProps) {
 
     const dateObj = timestamp ? new Date(timestamp) : null;
     const formattedTime: string = dateObj && !isNaN(dateObj.getTime()) 
-        ? dateObj.toLocaleString([], { hour: '2-digit', minute: '2-digit' }) 
+        ? dateObj.toLocaleString([], { month: '2-digit', day: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' }) 
         : "";
 
     return (


### PR DESCRIPTION
**_AI-Generated Description_**

### Summary
Updated the chat message timestamps to display the date alongside the time. This helps users track when messages were sent and identify gaps between active practice sessions.

### Changes
- **`templates/components/TalkWithTito/Messages.tsx`**: Updated `formattedTime` using localized options to include the month, day, and year (e.g. `06/18/2026, 06:41 PM`).

